### PR TITLE
Verify the invite before allowing user creation

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,5 +1,6 @@
 class UserController < ApplicationController
 
+  before_action :verified_user_invite, :only => [:new, :create]
   skip_before_action :login_required, :only => [:new, :create]
   skip_before_action :verified_email_required, :only => [:edit, :update, :verify]
 
@@ -24,7 +25,7 @@ class UserController < ApplicationController
   end
 
   def join
-    if @invite = UserInvite.where(:uuid => params[:token]).where("expires_at > ?", Time.now).first
+    if @invite = UserInvite.find_valid_by_uuid(params[:token])
       if request.post?
         @invite.accept(current_user)
         redirect_to_with_json root_path(:nrd => 1), :notice => "Invitation has been accepted successfully. You now have access to this organization."
@@ -83,6 +84,20 @@ class UserController < ApplicationController
       else
         flash_now :alert, "The code you've entered isn't correct. Please check and try again."
       end
+    end
+  end
+
+  private
+
+  def verified_user_invite
+    if Postal.config.general.disable_signup
+      if params[:return_to]
+        if UserInvite.find_valid_by_uuid(params[:return_to][/\/join\/([^\/]+)\/?/, 1])
+          return
+        end
+        flash[:alert] = "The invite URL you have has expired. Please ask the person who invited you to re-send your invitation."
+      end
+      redirect_to login_path
     end
   end
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -5,12 +5,8 @@ class UserController < ApplicationController
   skip_before_action :verified_email_required, :only => [:edit, :update, :verify]
 
   def new
-    if Postal.config.general.disable_signup
-      redirect_to login_path
-    else
-      @user = User.new
-      render :layout => 'sub'
-    end
+    @user = User.new
+    render :layout => 'sub'
   end
 
   def create

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -51,4 +51,9 @@ class UserInvite < ApplicationRecord
     self.destroy
   end
 
+  def self.find_valid_by_uuid(uuid)
+    return nil if uuid.blank?
+    self.where(:uuid => params[:token]).where("expires_at > ?", Time.now).first
+  end
+
 end

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -14,7 +14,7 @@
     .loginForm__submit
       %ul.loginForm__links
         %li= link_to "Forgotten your password?", login_reset_path(:return_to => params[:return_to])
-        - unless Postal.config.general.disable_signup
+        - if !Postal.config.general.disable_signup || params[:return_to] =~ /\/join\//
           %li= link_to "Create a new user", signup_path(:return_to => params[:return_to])
       %p= submit_tag "Login", :class => 'button button--positive', :tabindex => 3
 


### PR DESCRIPTION
As discussed in atech/postal#64, by validating the invite uuid users can still singup via invitation but users without an invite cannot signup.